### PR TITLE
Downgrade dj-database-url

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -3,7 +3,7 @@ pytz==2016.10
 pylibmc==1.5.1
 psycopg2==2.6.2
 Pillow==3.4.2
-dj-database-url==0.4.2
+dj-database-url==0.4.1
 raven==5.32.0
 
 # Storage


### PR DESCRIPTION
Avoid a regression in 0.4.2, which will hopefully be fixed by https://github.com/kennethreitz/dj-database-url/pull/84 at some point in the future