### PR TITLE
Add coverage reports

### DIFF
--- a/{{cookiecutter.project_slug}}/.coveragerc
+++ b/{{cookiecutter.project_slug}}/.coveragerc
@@ -1,5 +1,6 @@
 [run]
-omit =../*migrations*
+branch = True
+omit = *migrations*
 
 [xml]
-output=reports/coverage.xml
+output = reports/coverage.xml

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -8,6 +8,8 @@
 # Testing
 .coverage
 .tox
+htmlcov
+reports
 
 # Grunt
 /node_modules

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -8,3 +8,5 @@ tox==2.6.0
 spectrum-python==0.9.8
 flake8==3.3.0
 isort==4.2.5
+unittest-xml-reporting==2.1.0
+coverage==4.3.4

--- a/{{cookiecutter.project_slug}}/requirements/testing.txt
+++ b/{{cookiecutter.project_slug}}/requirements/testing.txt
@@ -3,3 +3,5 @@
 django-extensions==1.7.6
 flake8==3.3.0
 isort==4.2.5
+unittest-xml-reporting==2.1.0
+coverage==4.3.4

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django, flake8, isort
+envlist = django, flake8, isort, coverage
 skipsdist = true
 
 [testenv]
@@ -20,7 +20,7 @@ commands =
     {toxinidir}/manage.py validate_templates --verbosity 0
     bash -c "! {toxinidir}/manage.py makemigrations --dry-run --exit"
     {toxinidir}/manage.py drop_test_database --noinput
-    {toxinidir}/manage.py test --noinput
+    coverage run --omit="{envdir}/*" {toxinidir}/manage.py test --noinput
 setenv =
     DJANGO_SETTINGS_MODULE = {{ cookiecutter.project_slug }}.settings.tox
     STATIC_ROOT = {envtmpdir}/static
@@ -33,3 +33,9 @@ commands =
 [testenv:isort]
 commands =
     isort --recursive --check-only --diff {{ cookiecutter.project_slug }} apps
+
+[testenv:coverage]
+commands =
+    coverage report --show-missing
+    coverage html
+    coverage xml

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/tox.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/tox.py
@@ -18,3 +18,10 @@ STATIC_ROOT = os.environ['STATIC_ROOT']
 INSTALLED_APPS += [
     'django_extensions',
 ]
+
+
+# Test Runner
+# - Use XMLTestRunner for tox to output per test XML files
+# - Output these to a separate directory to avoid clutter
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = 'reports'


### PR DESCRIPTION
Adds support for HTML reports (useful for local development), and XML reports which Jenkins will pick up and process after a test run.

Closes #43 
