### PR TITLE
Stick with the default show toolbar for django-debug-toolbar

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
@@ -47,7 +47,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
 # Django debug toolbar - show locally unless DISABLE_TOOLBAR is enabled with environment vars
-# eg. DISABLE_TOOLBAR=0 ./manage.py runserver
+# eg. DISABLE_TOOLBAR=1 ./manage.py runserver
 if not os.environ.get('DISABLE_TOOLBAR'):
     INSTALLED_APPS += [
         'debug_toolbar',

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
@@ -36,18 +36,6 @@ else:
     INSTALLED_APPS.insert(0, 'flat')
 
 
-# Django debug toolbar - show locally unless DEBUG_TOOLBAR is turned off with environment vars
-# eg. DEBUG_TOOLBAR=0 ./manage.py runserver
-if os.environ.get('DEBUG_TOOLBAR', '1') == '1':
-    INSTALLED_APPS += [
-        'debug_toolbar',
-    ]
-
-    MIDDLEWARE_CLASSES = [
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + MIDDLEWARE_CLASSES
-
-
 # Use vanilla StaticFilesStorage to allow tests to run outside of tox easily
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
@@ -56,6 +44,18 @@ SECRET_KEY = '{{ cookiecutter.project_slug }}'
 
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+
+# Django debug toolbar - show locally unless DISABLE_TOOLBAR is enabled with environment vars
+# eg. DISABLE_TOOLBAR=0 ./manage.py runserver
+if not os.environ.get('DISABLE_TOOLBAR'):
+    INSTALLED_APPS += [
+        'debug_toolbar',
+    ]
+
+    MIDDLEWARE_CLASSES = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + MIDDLEWARE_CLASSES
 
 
 # Only enable spectrum logging if requested, as the spectrum app needs to be loaded

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings/local.py
@@ -36,26 +36,16 @@ else:
     INSTALLED_APPS.insert(0, 'flat')
 
 
-# Django debug toolbar - always show locally unless DEBUG_TOOLBAR is turned off
+# Django debug toolbar - show locally unless DEBUG_TOOLBAR is turned off with environment vars
 # eg. DEBUG_TOOLBAR=0 ./manage.py runserver
-def show_toolbar(request):
-    if request.is_ajax():
-        return False
+if os.environ.get('DEBUG_TOOLBAR', '1') == '1':
+    INSTALLED_APPS += [
+        'debug_toolbar',
+    ]
 
-    return os.environ.get('DEBUG_TOOLBAR', '1') == '1'
-
-
-INSTALLED_APPS += [
-    'debug_toolbar',
-]
-
-MIDDLEWARE_CLASSES = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-] + MIDDLEWARE_CLASSES
-
-DEBUG_TOOLBAR_CONFIG = {
-    'SHOW_TOOLBAR_CALLBACK': '{}.show_toolbar'.format(__name__),
-}
+    MIDDLEWARE_CLASSES = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + MIDDLEWARE_CLASSES
 
 
 # Use vanilla StaticFilesStorage to allow tests to run outside of tox easily


### PR DESCRIPTION
We enabled this at some point to make it easier for local development so that any IP accessing the local development server will see the django debug toolbar. - such as using a LAN IP address from a virtual machine. This seems to have gone a bit too far.

Instead we now assume that if you want to access the debug toolbar you'll always be doing it locally over 127.0.0.1.

Fixes #48.